### PR TITLE
Separate compilation from host application

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ Rails.application.routes.draw do
 end
 ```
 
-_Note: If you encounter an AssetNotPrecompiled error when accessing the UI, try one of the following_
-* Add `//= link lightning/application.css` to `app/assets/config/manifest.js`
-* Add `config.assets.check_precompiled_asset = false` to your `development.rb` (or other environment file) 
-
 ## Functionality
 * Easy-to-use UI that allows creating, modifying, and deleting features and permissioning entities to those features
 * Highly configurable options to display data on the UI

--- a/lib/lightning/engine.rb
+++ b/lib/lightning/engine.rb
@@ -2,6 +2,10 @@ module Lightning
   class Engine < ::Rails::Engine
     isolate_namespace Lightning
 
+    initializer "lightning.assets.precompile" do |app|
+      app.config.assets.precompile += %w( lightning/application.css )
+    end
+
     config.generators do |g|
       g.test_framework :rspec
     end


### PR DESCRIPTION
More info here: https://guides.rubyonrails.org/engines.html#separate-assets-and-precompiling.

This doesn't require any effort on the host application to configure compilation of assets.