### PR TITLE
Add custom feature flag permission

### DIFF
--- a/app/controllers/lightning/feature_opt_criterions_controller.rb
+++ b/app/controllers/lightning/feature_opt_criterions_controller.rb
@@ -1,0 +1,27 @@
+require_dependency "lightning/application_controller"
+
+module Lightning
+  class FeatureOptCriterionsController < ApplicationController
+
+    def create
+      @feature = Feature.find(params[:feature_id])
+      criterion = JSON.parse(params[:feature_opt_criterion][:criterion_type])
+      entity_type = criterion[0]
+      entity_method = criterion[1]
+
+      @feature.feature_opt_criterions.find_or_create_by!(entity_type: entity_type, entity_method: entity_method)
+      flash[:notice] = "Permissions has been created!"
+      redirect_to @feature
+    rescue => e
+      flash[:notice] = "Failed to opt in some entities: #{e.message}"
+      redirect_to @feature
+    end
+
+    def destroy
+      @feature = Feature.find(params[:feature_id])
+      @feature_opt_criterion = @feature.feature_opt_criterions.find(params[:id])
+      @feature_opt_criterion.destroy
+      redirect_to @feature, notice: 'Feature permission was successfully destroyed.'
+    end
+  end
+end

--- a/app/controllers/lightning/features_controller.rb
+++ b/app/controllers/lightning/features_controller.rb
@@ -10,6 +10,19 @@ module Lightning
 
     def show
       @flaggable_entities = Lightning.flaggable_entities
+
+      @criterion_select_options = []
+      @criterion_method_id_name_map = {}
+      @flaggable_entities.each do |entity|
+        entity_str = entity.to_s
+        @criterion_method_id_name_map[entity_str] = {}
+        entity.new.lightning_criterions.each do |criterion|
+          display_name = criterion[:display_name]
+          criterion_id = criterion[:id]
+          @criterion_select_options << ["#{entity_str} - #{display_name}", [entity_str, criterion_id]]
+          @criterion_method_id_name_map[entity_str][criterion_id] = display_name
+        end
+      end
     end
 
     def new

--- a/app/helpers/lightning/flaggable.rb
+++ b/app/helpers/lightning/flaggable.rb
@@ -7,5 +7,11 @@ module Lightning
         self.id
       end
     end
+
+    # List of 3-element hashes containing a unique id, method, and display name
+    # (i.e [{id: 1, method: :free, display_name: "Free Tier"}])
+    def lightning_criterions
+      []
+    end
   end
 end

--- a/app/models/lightning/feature.rb
+++ b/app/models/lightning/feature.rb
@@ -3,6 +3,7 @@ module Lightning
 
     enum state: { disabled: 0, enabled_globally: 1, enabled_per_entity: 2 }
     has_many :feature_opt_ins
+    has_many :feature_opt_criterions
 
     def enabled?
       !disabled?

--- a/app/models/lightning/feature_opt_criterion.rb
+++ b/app/models/lightning/feature_opt_criterion.rb
@@ -1,0 +1,8 @@
+module Lightning
+  class FeatureOptCriterion < ApplicationRecord
+    belongs_to :feature
+
+    validates :entity_type, presence: true
+    validates :entity_method, presence: true
+  end
+end

--- a/app/views/lightning/features/show.html.erb
+++ b/app/views/lightning/features/show.html.erb
@@ -74,6 +74,28 @@
   </div>
 
   <div class="mt-5">
+    <%= form_with model: [@feature, @feature.feature_opt_criterions.build] do |form| %>
+      <div>
+        <label class="form-label">Enable feature with criteria</label>
+      </div>
+      <div class="row g-3">
+        <div class="col-auto">
+          <%=
+            form.select :criterion_type,
+                        options_for_select(@criterion_select_options),
+                        {},
+                        { class: "form-select" }
+          %>
+        </div>
+        <div class="col-auto">
+          <%= form.submit 'Save', class: "btn btn-primary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+
+  <div class="mt-5">
     <h3>
       Opt Ins
       <small class="text-muted">(<%= @feature.feature_opt_ins.count %>)</small>
@@ -86,14 +108,39 @@
         <% @feature.feature_opt_ins.each do |feature_opt_in| %>
           <% next if feature_opt_in.new_record? %>
           <tbody>
-            <tr>
-              <td><code><%= feature_opt_in.entity.class %></code><td>
-              <td><%= feature_opt_in.entity_name %></td>
-              <td><%= button_to 'Opt out', [feature_opt_in.feature, feature_opt_in], class: "btn btn-light btn-sm", method: :delete, data: { confirm: 'Are you sure?' } %></td>
-            </tr>
+          <tr>
+            <td><code><%= feature_opt_in.entity.class %></code><td>
+            <td><%= feature_opt_in.entity_name %></td>
+            <td><%= button_to 'Opt out', [feature_opt_in.feature, feature_opt_in], class: "btn btn-light btn-sm", method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          </tr>
           </tbody>
         <% end %>
       </table>
     <% end %>
   </div>
+
+  <div class="mt-5">
+    <h3>
+      Opt In Criterias
+      <small class="text-muted">(<%= @feature.feature_opt_criterions.count %>)</small>
+    </h3>
+
+    <% if @feature.feature_opt_criterions.reject(&:new_record?).empty? %>
+      <p class="lead text-muted">👌 No criteria opted in yet.</p>
+    <% else %>
+      <table class="table table-sm">
+        <% @feature.feature_opt_criterions.each do |feature_opt_criterion| %>
+          <% next if feature_opt_criterion.new_record? %>
+          <tbody>
+          <tr>
+            <td><code><%= feature_opt_criterion.entity_type %></code><td>
+            <td><%= @criterion_method_id_name_map[feature_opt_criterion.entity_type][feature_opt_criterion.entity_method.to_i] %><td>
+            <td><%= button_to 'Opt out', [feature_opt_criterion.feature, feature_opt_criterion], class: "btn btn-light btn-sm", method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          </tr>
+          </tbody>
+        <% end %>
+      </table>
+    <% end %>
+  </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Lightning::Engine.routes.draw do
 
   resources :features do
     resources :feature_opt_ins
+    resources :feature_opt_criterions
   end
 end

--- a/db/migrate/20210611132548_add_feature_opt_criterion_table.rb
+++ b/db/migrate/20210611132548_add_feature_opt_criterion_table.rb
@@ -1,0 +1,15 @@
+class AddFeatureOptCriterionTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :lightning_feature_opt_criterions do |t|
+      t.integer :feature_id, null: false
+      t.string :entity_type, null: false
+      t.string :entity_method, null: false
+
+      t.timestamps
+    end
+
+    add_index :lightning_feature_opt_criterions, [:entity_type, :entity_method], name: 'criterion_entity_index'
+    add_index :lightning_feature_opt_criterions, [:feature_id, :entity_type, :entity_method], unique: true, name: 'criterion_uniq_index'
+
+  end
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -3,4 +3,15 @@ class User < ApplicationRecord
 
   # has_many :feature_opt_ins, as: :entity
 
+  def lightning_criterions
+    [{ id: 1, method: :is_free, display_name: "Free Tier" }, { id: 2, method: :is_paid, display_name: "Pro Tier" }]
+  end
+
+  def is_paid
+    false
+  end
+
+  def is_free
+    true
+  end
 end

--- a/test/dummy/db/migrate/20210611134251_add_feature_opt_criterion_table.lightning.rb
+++ b/test/dummy/db/migrate/20210611134251_add_feature_opt_criterion_table.lightning.rb
@@ -1,0 +1,16 @@
+# This migration comes from lightning (originally 20210611132548)
+class AddFeatureOptCriterionTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :lightning_feature_opt_criterions do |t|
+      t.integer :feature_id, null: false
+      t.string :entity_type, null: false
+      t.string :entity_method, null: false
+
+      t.timestamps
+    end
+
+    add_index :lightning_feature_opt_criterions, [:entity_type, :entity_method], name: 'criterion_entity_index'
+    add_index :lightning_feature_opt_criterions, [:feature_id, :entity_type, :entity_method], unique: true, name: 'criterion_uniq_index'
+
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_164611) do
+ActiveRecord::Schema.define(version: 2021_06_11_134251) do
+
+  create_table "lightning_feature_opt_criterions", force: :cascade do |t|
+    t.integer "feature_id", null: false
+    t.string "entity_type", null: false
+    t.string "entity_method", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_type", "entity_method"], name: "criterion_entity_index"
+    t.index ["feature_id", "entity_type", "entity_method"], name: "criterion_uniq_index", unique: true
+  end
 
   create_table "lightning_feature_opt_ins", force: :cascade do |t|
     t.integer "feature_id", null: false


### PR DESCRIPTION
With this approach, any ActiveRecord method can be a criteria to opt into a feature flag. For example, in the model below, we can toggle feature flags on two methods defined in `lightning_criterions`.

```ruby
class User < ApplicationRecord
  include Lightning::Flaggable

  # has_many :feature_opt_ins, as: :entity

  def lightning_criterions
    [{ id: 1, method: :is_free, display_name: "Free Tier" }, { id: 2, method: :is_paid, display_name: "Pro Tier" }]
  end

  def is_paid
    false
  end

  def is_free
    true
  end
end
```

The UI will show the following and can choose which method to rely on. 

![Screen Shot 2021-06-11 at 11 41 42 AM](https://user-images.githubusercontent.com/4913664/121712721-0d38a800-caaa-11eb-9e87-5c9d11afcd6f.png)

Thoughts on this approach?